### PR TITLE
fix(scheduler): Final refactor to fix recurring job logic

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -1,29 +1,25 @@
 import logging
 from copy import deepcopy
+from sqlalchemy.orm import Session
 
-from database import SessionLocal
 from models import Schedule, Content
 from automation import ContentUploader
 
 logger = logging.getLogger(__name__)
 
-from sqlalchemy.orm import Session
-
-async def execute_upload_logic(db: Session, schedule: Schedule):
+async def execute_upload_logic(db: Session, schedule: Schedule) -> bool:
     """
     This is the core logic that performs the upload for a given schedule.
-    It uses the database session passed from the caller.
+    It uses the database session passed from the caller and returns True/False.
+    It does NOT commit any changes to the database.
     """
     logger.info(f"--- Executing job for schedule_id: {schedule.id} ---")
     try:
-        # The schedule object is already in the session from the caller.
         content_to_upload = db.query(Content).filter(Content.id == schedule.content_id).first()
         if not content_to_upload:
             logger.error(f"Execution failed: Content {schedule.content_id} not found for schedule {schedule.id}.")
-            schedule.status = "failed"
-            schedule.error_message = "Content not found"
-            db.commit()
-            return
+            # The caller will handle the status update
+            return False
 
         # For recurring jobs with a day counter, we create a temporary copy
         # of the content to modify its caption.
@@ -41,29 +37,14 @@ async def execute_upload_logic(db: Session, schedule: Schedule):
         success = await uploader.upload_to_platform(content_for_this_run, schedule.platform)
 
         if success:
-            logger.info(f"✅ Successfully uploaded content for schedule {schedule.id}.")
-            if schedule.status == 'pending':
-                schedule.status = "completed"
-                content_to_upload.status = "published"
-            elif schedule.status == 'recurring':
-                if schedule.use_day_counter:
-                    schedule.day_counter += 1
-                    logger.info(f"Incremented day counter for schedule {schedule.id} to {schedule.day_counter}.")
+            logger.info(f"✅ Upload successful for schedule {schedule.id}.")
+            return True
         else:
-            schedule.status = "failed"
-            schedule.error_message = "Upload process returned failure."
-            logger.error(f"❌ Failed to upload content for schedule {schedule.id}.")
-
-        db.commit()
+            logger.error(f"❌ Upload process returned failure for schedule {schedule.id}.")
+            return False
 
     except Exception as e:
         logging.error(f"An unexpected error in execute_upload_logic for schedule {schedule.id}: {e}", exc_info=True)
-        # Make sure to get a fresh object in the current session for update
-        schedule_to_fail = db.query(Schedule).filter(Schedule.id == schedule.id).first()
-        if schedule_to_fail:
-            schedule_to_fail.status = "failed"
-            schedule_to_fail.error_message = str(e)
-            db.commit()
+        return False
     finally:
-        # The session is managed by the caller, so we don't close it here.
-        logger.info(f"--- Finished execution for schedule_id: {schedule.id} ---")
+        logger.info(f"--- Finished execution attempt for schedule_id: {schedule.id} ---")


### PR DESCRIPTION
This commit performs the final refactor of the custom scheduler service to fix a critical bug where recurring jobs would only run once.

The root cause was improper database state management after a job's execution. The logic has been redesigned to be more robust:

1.  **`scheduler.py` Simplified**: The `execute_upload_logic` function is now a pure function responsible only for the upload attempt. It no longer performs any database commits and simply returns `True` or `False`.

2.  **State Logic Consolidated in `run_scheduler.py`**: The main service loop in `run_scheduler.py` is now the single source of truth for all state changes. After calling `execute_upload_logic`, it is responsible for:
    - Marking one-time jobs as 'completed'.
    - Updating the `last_run_at` timestamp for recurring jobs to ensure they run again the next day.
    - Incrementing the day counter.
    - Marking failed jobs correctly.

This consolidation resolves the bug and makes the entire scheduling system more reliable and easier to maintain. This should be the definitive fix for all reported scheduling issues.